### PR TITLE
Fix potential vulnerable cloned function

### DIFF
--- a/src/sds.c
+++ b/src/sds.c
@@ -101,6 +101,7 @@ sds sdsnewlen(const void *init, size_t initlen) {
     int hdrlen = sdsHdrSize(type);
     unsigned char *fp; /* flags pointer. */
 
+    assert(initlen + hdrlen + 1 > initlen); /* Catch size_t overflow */ 
     sh = s_malloc(hdrlen+initlen+1);
     if (init==SDS_NOINIT)
         init = NULL;
@@ -219,6 +220,7 @@ sds sdsMakeRoomFor(sds s, size_t addlen) {
     len = sdslen(s);
     sh = (char*)s-sdsHdrSize(oldtype);
     newlen = (len+addlen);
+    assert(newlen > len);   /* Catch size_t overflow */
     if (newlen < SDS_MAX_PREALLOC)
         newlen *= 2;
     else
@@ -232,6 +234,7 @@ sds sdsMakeRoomFor(sds s, size_t addlen) {
     if (type == SDS_TYPE_5) type = SDS_TYPE_8;
 
     hdrlen = sdsHdrSize(type);
+    assert(hdrlen + newlen + 1 > len);  /* Catch size_t overflow */
     if (oldtype==type) {
         newsh = s_realloc(sh, hdrlen+newlen+1);
         if (newsh == NULL) return NULL;

--- a/src/zmalloc.c
+++ b/src/zmalloc.c
@@ -64,6 +64,12 @@ POSIX_ONLY(#include <pthread.h>)
 #endif
 #endif
 
+#if PREFIX_SIZE > 0
+#define ASSERT_NO_SIZE_OVERFLOW(sz) assert((sz) + PREFIX_SIZE > (sz))
+#else
+#define ASSERT_NO_SIZE_OVERFLOW(sz)
+#endif
+
 /* Explicitly override malloc/free etc when using tcmalloc. */
 #if defined(USE_TCMALLOC)
 #define malloc(size) tc_malloc(size)
@@ -126,6 +132,7 @@ void *zmalloc(size_t size) {
  * Currently implemented only for jemalloc. Used for online defragmentation. */
 #ifdef HAVE_DEFRAG
 void *zmalloc_no_tcache(size_t size) {
+    ASSERT_NO_SIZE_OVERFLOW(size);
     void *ptr = mallocx(size+PREFIX_SIZE, MALLOCX_TCACHE_NONE);
     if (!ptr) zmalloc_oom_handler(size);
     update_zmalloc_stat_alloc(zmalloc_size(ptr));


### PR DESCRIPTION
Our tool identified a potential vulnerability in clone functions in `src/zmalloc.c` and `src/sds.c` sourced from [redis/redis](https://github.com/redis/redis). These issues, originally reported in [CVE-2021-21309](https://nvd.nist.gov/vuln/detail/CVE-2021-21309), were resolved in the repository via this commit https://github.com/redis/redis/commit/d32f2e9999ce003bad0bd2c3bca29f64dcce4433.

This PR applies the corresponding patch to fix the vulnerabilities in this codebase.

Please review at your convenience.